### PR TITLE
Update tidy.conf

### DIFF
--- a/BOOK/tidy.conf
+++ b/BOOK/tidy.conf
@@ -7,10 +7,8 @@ newline: CRLF
 write-back: yes
 markup: yes
 indent: yes
-hide-endtags: no
 uppercase-tags: no
 logical-emphasis: no
-drop-font-tags: no
 tidy-mark: no
 numeric-entities: no
 show-warnings: no


### PR DESCRIPTION
Remove obsolete tidy options:

With recent versions of tidy-html5, two options have been obsoleted and
generate warnings: hide-endtags and drop-font-tags. Those options can
just be removed, since they are set to "no", which is the default in
any case.
